### PR TITLE
Cadence timing tweaks and working around Garmin.

### DIFF
--- a/src/app/simulation.js
+++ b/src/app/simulation.js
@@ -1,5 +1,7 @@
 import {EventEmitter} from 'events';
 
+const CADENCE_DELTA = .5
+
 /**
  * Emit pedal stroke events at a rate that matches the given target cadence.
  * The target cadence can be updated on-the-fly.
@@ -8,18 +10,19 @@ export class Simulation extends EventEmitter {
   constructor() {
     super();
     this._cadence = 0;
+    this._requestedCadence = 0;
     this._interval = Infinity;
     this._lastPedalTime = -Infinity;
     this._timeoutId = null;
   }
 
   /**
-   * Set the target cadence.
-   * @param {number} cadence - the target cadence in rpm.
+   * 
+   * @param {number} cadence - the target cadence in rpm 
+   * @private
    */
-  set cadence(x) {
-    this._cadence = x;
-    this._interval = x > 0 ? 1000 * (60 / this._cadence) : Infinity;
+  updateInterval(x) {
+    this._interval = x > 0 ? 1000 * (60 / x) : Infinity;
     if (this._timeoutId) {
       clearTimeout(this._timeoutId);
       this._timeoutId = null;
@@ -27,11 +30,26 @@ export class Simulation extends EventEmitter {
     this.schedulePedal();
   }
 
+
+  /**
+   * Set the target cadence.
+   * @param {number} cadence - the target cadence in rpm.
+   */
+  set cadence(x) {
+    var newCadence = x
+    if (this._requestedCadence != newCadence){
+      this._cadence = newCadence;
+      this.updateInterval(this._cadence);
+      this._requestedCadence = newCadence
+    }
+  }
+
+
   /**
    * Get the current target cadence (rpm).
    */
   get cadence() {
-    return this._cadence;
+    return this._requestedCadence;
   }
 
   /**
@@ -40,7 +58,27 @@ export class Simulation extends EventEmitter {
    * @private
    */
   onPedal() {
+    let timeSinceLast = Date.now() - this._lastPedalTime;
+    // Since the BLE timestamp is in units of 1/1024ths of a second
+    // we have precision loss. This, with the fact that javascript
+    // interval timers are not precise means we need to attempt to
+    // correct on the fly. This brings the imprecision down from 5rpm
+    // too high to around 1-2.
+    let quantumLast = Math.floor(timeSinceLast * (1000 / 1024))
+    let effectiveCadence = (60 * 1000) / quantumLast;
+    console.log("Effective Cadence: " + effectiveCadence);
     this._lastPedalTime = Date.now();
+    if (timeSinceLast !== Infinity){
+      if (effectiveCadence > this.cadence){
+        this._cadence -= CADENCE_DELTA
+        this.updateInterval(this._cadence)
+      }
+      else if (effectiveCadence < this.cadence){
+        this._cadence += CADENCE_DELTA
+        this.updateInterval(this._cadence);
+      }
+    }
+
     /**
      * Pedal event.
      * @event Simulation#pedal
@@ -55,12 +93,8 @@ export class Simulation extends EventEmitter {
    */
   schedulePedal() {
     if (this._interval === Infinity) return;
-
-    let timeSinceLast = Date.now() - this._lastPedalTime;
-    let timeUntilNext = Math.max(0, this._interval - timeSinceLast);
-    this._timeoutId = setTimeout(() => {
+    this._timeoutId = setInterval(() => {
       this.onPedal();
-      this.schedulePedal();
-    }, timeUntilNext);
+    }, this._interval);
   }
 }


### PR DESCRIPTION
Noticed that Zwift, TR and my Garmin all displayed around 5rpm too high even when using the bot simulator. While the requested intervals are correct, the actual scheduler has some variability, and I added a really simple control mechanism to tune closer to the correct RPM.

Additionally, testing on a Garmin 530 showed that, while watts were displaying properly, cadence would experience drops to "---" (i.e. null).  While the BLE spec allows frames to not contain crank information, the Garmin device was unhappy with that. Since it uses time deltas between timestamps, we can resend the last crank information with the same timestamp and count and allow the display to maintain the last known cadence.