### PR TITLE
Support for resistance change

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,4 +1,5 @@
 import {CyclingPowerService} from './services/cycling-power'
+import {FitnessMachineService} from './services/fitness-machine'
 import {BleServer} from '../util/ble-server'
 
 export const DEFAULT_NAME = 'Gymnasticon';
@@ -14,7 +15,8 @@ export class GymnasticonServer extends BleServer {
 	 */
   constructor(bleno, name=DEFAULT_NAME) {
     super(bleno, name, [
-      new CyclingPowerService()
+      new CyclingPowerService(),
+      new FitnessMachineService()
     ])
   }
 

--- a/src/server/services/fitness-machine/characteristics/fitness-machine-control-point.js
+++ b/src/server/services/fitness-machine/characteristics/fitness-machine-control-point.js
@@ -1,0 +1,63 @@
+import {Characteristic, Descriptor} from '@abandonware/bleno';
+
+const FLAG_HASCRANKDATA = (1<<5);
+const CRANK_TIMESTAMP_SCALE = 1000 / 1024; // timestamp resolution is 1/1024 sec
+
+/**
+ * Bluetooth LE GATT Cycling Power Measurement Characteristic implementation.
+ */
+export class FitnessMachineControlPoint extends Characteristic {
+  constructor() {
+    super({
+      uuid: '2AD9',
+      properties: ['read', 'write'],
+      descriptors: [
+        new Descriptor({
+          uuid: '2902',
+          value: Buffer.alloc(2)
+        }),
+        new Descriptor({
+          uuid: '2903',
+          value: Buffer.alloc(2)
+        })
+      ]
+    })
+  }
+  onWriteRequest () {
+      console.log('write request', arguments)
+  }
+  onReadRequest (a, callback) {
+    console.log('read request', arguments)
+    callback(Buffer.from([0x80, 1]))
+  }
+
+  /**
+   * Notify subscriber (e.g. Zwift) of new Cycling Power Measurement.
+   * @param {object} measurement - new cycling power measurement.
+   * @param {number} measurement.power - current power (watts)
+	 * @param {object} [measurement.crank] - last crank event.
+   * @param {number} measurement.crank.revolutions - revolution count at last crank event.
+   * @param {number} measurement.crank.timestamp - timestamp at last crank event.
+   */
+//   updateMeasurement({ power, crank }) {
+//     let flags = 0;
+
+//     const value = Buffer.alloc(8);
+//     value.writeInt16LE(power, 2);
+
+//     // include crank data if provided
+//     if (crank) {
+//       const revolutions16bit = crank.revolutions & 0xffff;
+//       const timestamp16bit = Math.floor(crank.timestamp * CRANK_TIMESTAMP_SCALE) & 0xffff;
+//       value.writeUInt16LE(revolutions16bit, 4);
+//       value.writeUInt16LE(timestamp16bit, 6);
+//       flags |= FLAG_HASCRANKDATA;
+//     }
+
+//     value.writeUInt16LE(flags, 0);
+
+//     if (this.updateValueCallback) {
+//       this.updateValueCallback(value)
+//     }
+//   }
+}

--- a/src/server/services/fitness-machine/characteristics/fitness-machine-feature.js
+++ b/src/server/services/fitness-machine/characteristics/fitness-machine-feature.js
@@ -1,0 +1,31 @@
+import {Characteristic, Descriptor} from '@abandonware/bleno';
+
+/**
+ * Bluetooth LE GATT Cycling Power Feature Characteristic implementation.
+ */
+export class FitnessMachineFeatureCharacteristic extends Characteristic {
+  constructor() {
+    super({
+      uuid: '2ACC',
+      properties: ['read'],
+      descriptors: [
+        new Descriptor({
+          uuid: '2901',
+          value: 'Fitness Machine Feature'
+        })
+      ],
+      value: Buffer.from([
+        // Resistance Level Supported
+        1,
+        0,
+        0,
+        0,
+        // Resistance Target Setting Supported
+        32,
+        0,
+        0,
+        0
+      ])
+    })
+  }
+}

--- a/src/server/services/fitness-machine/index.js
+++ b/src/server/services/fitness-machine/index.js
@@ -1,0 +1,35 @@
+import {PrimaryService} from '@abandonware/bleno';
+import {FitnessMachineFeatureCharacteristic} from './characteristics/fitness-machine-feature';
+import {FitnessMachineControlPoint} from './characteristics/fitness-machine-control-point';
+// import {SensorLocationCharacteristic} from './characteristics/sensor-location';
+
+/**
+ * Bluetooth LE GATT Cycling Power Service implementation.
+ */
+export class FitnessMachineService extends PrimaryService {
+  /**
+   * Create a FitnessMachineService instance.
+   */
+  constructor() {
+    super({
+      uuid: '1818',
+      characteristics: [
+        new FitnessMachineFeatureCharacteristic(),
+        new FitnessMachineControlPoint(),
+        // new SensorLocationCharacteristic(),
+      ]
+    })
+  }
+
+  /**
+   * Notify subscriber (e.g. Zwift) of new Cycling Power Measurement.
+   * @param {object} measurement - new cycling power measurement.
+   * @param {number} measurement.power - current power (watts)
+	 * @param {object} [measurement.crank] - last crank event.
+   * @param {number} measurement.crank.revolutions - revolution count at last crank event.
+   * @param {number} measurement.crank.timestamp - timestamp at last crank event.
+   */
+//   updateMeasurement(measurement) {
+//     this.characteristics[0].updateMeasurement(measurement)
+//   }
+}


### PR DESCRIPTION
@ptx2 I was inspired after reading your dev notes a couple of months ago and ended up attaching a raspberry pi to my spin bike, https://www.diamondbackfitness.com/products/510ic-indoor-cycle . The down button for resistance was broken on the bike's built in screen so I replaced all of the logic with a pi and connected it to zwift using gymnasticon. Because of all the hardware involved I had to write the logic in python, which I connected to the "bot" bike using a UDP connection.

I built a custom UI (before I connected to zwift) where I can change the resistance, but changing apps from zwift to my UI to change resistance isn't the easiest thing to do while working out, so thought I'd try to build the BLE resistance change logic.

I've started to build out some BLE characteristics in this PR and the pi now shows up in zwift as supporting resistance change. I thought I'd start a draft PR, just in case you could help point me in the right direction.

A couple of things I'd love some help with
- [The BLE GATT docs](https://www.bluetooth.com/specifications/gatt/) are almost impossible to read! I'm not sure how you managed to connect everything just from the spec, were there any other resources you used to figure out the UUIDs and protocols?
- Do you know how the zwift command to change resistance would come through to a bleno characteristic? I was monitoring `onWriteRequest` but didn't see anything (I'm not really sure when zwift updates resistance, I assumed it would reset it at the start but perhaps I need to choose a hilly course to see it change)

Thanks so much for building this project and inspiring me, it's been nice to get back into some electronics!


