### PR TITLE
Remove phantom pedal strokes.

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -106,7 +106,6 @@ export class App {
   }
 
   onPedalStroke(timestamp) {
-    this.pingInterval.reset();
     this.crank.timestamp = timestamp;
     this.crank.revolutions++;
     let {power, crank} = this;
@@ -115,7 +114,8 @@ export class App {
   }
 
   onPingInterval() {
-    debuglog(`pinging app since no stats or pedal strokes for ${this.pingInterval.interval}s`);
+    debuglog(`pinging app since no stats received for ${this.pingInterval.interval}s`);
+    this.simulation.cadence = 0;
     let {power, crank} = this;
     this.server.updateMeasurement({ power, crank });
   }


### PR DESCRIPTION
If the last cadence received by gymnasticon is non-zero, we continue to fire off phantom pedal strokes (which continuously reset the pingInterval).  We can remove the pingInterval resetter from onPedalStroke, and force the cadence to zero if we receive a ping request (i.e. no stats received in the last second).

I've tested this from my Peloton and all looks good, but would need to have someone validate the flywheel behavior.

This should address https://github.com/ptx2/gymnasticon/issues/32
