### PR TITLE
Supports Raspberry Pi headless config for different bike types

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Steps:
 
 1. Download the latest [Gymnasticon SD card image](https://github.com/ptx2/gymnasticon/releases/latest/download/gymnasticon-raspberrypi.img.xz)
 2. Write the image to the SD card using Raspberry Pi Imager or `dd`
-3. If using another bike than the default 'Flywheel', create and adapt a 'gymnasticon.json' file within the boot partition of the SD card (See below)
+3. If using another bike than the default 'Flywheel' or 'Peloton', create and adapt a 'gymnasticon.json' file within the boot partition of the SD card (See below)
 4. Insert the SD card in the Raspberry Pi, power it up and wait a minute
 5. Start pedaling and Gymnasticon should appear in the Zwift device list
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Gymnasticon enables the obsolete Flywheel Home Bike to work with Zwift and other training apps. Support for other bikes can be added easily.
 
-The original Peloton Bike is now supported. Support requires a serial to USB adapter and custom wiring via RCA cables or through terminal blocks. For more details on setting up the hardware, see the [PR notes](https://github.com/ptx2/gymnasticon/pull/12). 
+The original Peloton Bike is now supported. Support requires a serial to USB adapter and custom wiring via RCA cables or through terminal blocks. For more details on setting up the hardware, see the [PR notes](https://github.com/ptx2/gymnasticon/pull/12).
 
 > Note: Peloton Bike+ is currently unsupported as it uses a USB-C connection and a (most likely) proprietary communications protocol.
 
@@ -53,8 +53,22 @@ Steps:
 
 1. Download the latest [Gymnasticon SD card image](https://github.com/ptx2/gymnasticon/releases/latest/download/gymnasticon-raspberrypi.img.xz)
 2. Write the image to the SD card using Raspberry Pi Imager or `dd`
+3. If using another bike than the default 'Flywheel', create and adapt a 'gymnasticon.json' file within the boot partition of the SD card (See below)
 3. Insert the SD card in the Raspberry Pi, power it up and wait a minute
 4. Start pedaling and Gymnasticon should appear in the Zwift device list
+
+Headless Config:
+The Gymnasticon SD card image allows headless configuration via a 'gymnasticon.json' file within the [boot partition](https://www.raspberrypi.org/documentation/configuration/boot_folder.md).
+
+The following example would configure the bike type to be IC4:
+
+```
+{
+  "bike": "ic4"
+}
+```
+
+See below for additional configuration options.
 
 Optional extra steps:
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Steps:
 1. Download the latest [Gymnasticon SD card image](https://github.com/ptx2/gymnasticon/releases/latest/download/gymnasticon-raspberrypi.img.xz)
 2. Write the image to the SD card using Raspberry Pi Imager or `dd`
 3. If using another bike than the default 'Flywheel', create and adapt a 'gymnasticon.json' file within the boot partition of the SD card (See below)
-3. Insert the SD card in the Raspberry Pi, power it up and wait a minute
-4. Start pedaling and Gymnasticon should appear in the Zwift device list
+4. Insert the SD card in the Raspberry Pi, power it up and wait a minute
+5. Start pedaling and Gymnasticon should appear in the Zwift device list
 
 Headless Config:
 The Gymnasticon SD card image allows headless configuration via a 'gymnasticon.json' file within the [boot partition](https://www.raspberrypi.org/documentation/configuration/boot_folder.md).

--- a/deploy/gymnasticon-mods.service
+++ b/deploy/gymnasticon-mods.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Copy user gymnasticon.json
+ConditionPathExists=/boot/gymnasticon.json
+Before=gymnasticon.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/mv /boot/gymnasticon.json /etc/gymnasticon.json
+ExecStartPost=/bin/chmod 600 /etc/gymnasticon.json
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/gymnasticon.service
+++ b/deploy/gymnasticon.service
@@ -10,7 +10,7 @@ Environment=PATH=/opt/gymnasticon/node/bin
 WorkingDirectory=/opt/gymnasticon
 User=pi
 Group=pi
-ExecStart=/opt/gymnasticon/node/bin/gymnasticon
+ExecStart=/opt/gymnasticon/node/bin/gymnasticon --config /etc/gymnasticon.json
 RestartSec=1
 Restart=always
 
@@ -19,4 +19,3 @@ NoNewPrivileges=true
 
 [Install]
 WantedBy=multi-user.target
-

--- a/deploy/pi-sdcard/stage-gymnasticon/00-install-gymnasticon/01-run.sh
+++ b/deploy/pi-sdcard/stage-gymnasticon/00-install-gymnasticon/01-run.sh
@@ -25,6 +25,7 @@ su ${GYMNASTICON_USER} -c 'export PATH=/opt/gymnasticon/node/bin:\$PATH; /opt/gy
 EOF
 
 install -v -m 644 files/gymnasticon.service "${ROOTFS_DIR}/etc/systemd/system/gymnasticon.service"
+install -v -m 644 files/gymnasticon-mods.service "${ROOTFS_DIR}/etc/systemd/system/gymnasticon-mods.service"
 
 on_chroot <<EOF
 systemctl enable gymnasticon


### PR DESCRIPTION
Addresses #44 to support headless config of Raspberry Pi via "gymnasticon.json" file in SD card /boot partition. 