### PR TITLE
Add gymnasticon to user pi's path

### DIFF
--- a/deploy/pi-sdcard/stage-gymnasticon/00-install-gymnasticon/01-run.sh
+++ b/deploy/pi-sdcard/stage-gymnasticon/00-install-gymnasticon/01-run.sh
@@ -17,6 +17,7 @@ if [ ! -x "${ROOTFS_DIR}/opt/gymnasticon/node/bin/node" ] ; then
     cd /opt/gymnasticon/node
     tar zxvf /tmp/node.tar.gz --strip 1
     chown -R "${GYMNASTICON_USER}:${GYMNASTICON_GROUP}" /opt/gymnasticon
+    echo "export PATH=/opt/gymnasticon/node/bin/:\$PATH" >> /home/pi/.profile
 EOF
 fi
 


### PR DESCRIPTION
To improve troubleshooting, add the directory /opt/gymnasticon/node/bin/ - where the executables for gymnasticon, node, and npm reside - to the $PATH variable for the user pi. This should address issue #46. 