### PR TITLE
Peloton Trace logging support

### DIFF
--- a/src/bikes/peloton.js
+++ b/src/bikes/peloton.js
@@ -1,6 +1,7 @@
 import {once, EventEmitter} from 'events';
 import {Timer} from '../util/timer';
 import util from 'util';
+import { trace } from 'console';
 
 const SerialPort = require('serialport')
 const Delimiter = require('@serialport/parser-delimiter')
@@ -9,6 +10,7 @@ const PACKET_DELIMITER = Buffer.from('f6', 'hex');
 const STATS_TIMEOUT = 1.0;
 
 const debuglog = util.debuglog('gymnasticon:bikes:peloton');
+const tracelog = util.debuglog('gymnasticon:bikes:peloton:trace');
 
 export class PelotonBikeClient extends EventEmitter {
   /**
@@ -40,11 +42,13 @@ export class PelotonBikeClient extends EventEmitter {
     this._port = new SerialPort(this.path, {baudRate: 19200, autoOpen: false});
     const open = util.promisify(this._port.open.bind(this._port));
     await open();
+    tracelog("Serial Opened")
     this._port.on('close', this.onSerialClose);
     this._parser = this._port.pipe(new Delimiter({ delimiter: PACKET_DELIMITER }));
     this._parser.on('data', this.onSerialMessage);
 
     this.state = 'connected';
+    tracelog("Serial Connected");
   }
 
   /**
@@ -64,27 +68,33 @@ export class PelotonBikeClient extends EventEmitter {
   }
 
   onSerialMessage(data) {
+    tracelog("RECV: ", data);
     switch(data[1]) {
-    case 65:
-      this.cadence = decodePeloton(data, data[2], false);
-      this.onStatsUpdate();
-      this.statsTimeout.reset();
-      return;
-    case 68:
-      this.power = decodePeloton(data, data[2], true);
-      this.onStatsUpdate();
-      this.statsTimeout.reset();
-      return;
-    }
+      case 65:
+        this.cadence = decodePeloton(data, data[2], false);
+        this.onStatsUpdate();
+        this.statsTimeout.reset();
+        return;
+      case 68:
+        this.power = decodePeloton(data, data[2], true);
+        this.onStatsUpdate();
+        this.statsTimeout.reset();
+        return;
+      default:
+        debuglog("Unrecognized Message Type: ", data[1]);
+        return;
+      }
   }
 
   onSerialClose() {
     this.emit('disconnect', {address: this.address});
+    tracelog("Serial Closed");
   }
 
   onStatsTimeout() {
     this.power = 0;
     this.cadence = 0;
+    tracelog("StatsTimeout exceeded");
     this.onStatsUpdate();
   }
 }

--- a/src/bikes/peloton.js
+++ b/src/bikes/peloton.js
@@ -41,7 +41,7 @@ export class PelotonBikeClient extends EventEmitter {
     this._port = new SerialPort(this.path, {baudRate: 19200, autoOpen: false});
     const open = util.promisify(this._port.open.bind(this._port));
     await open();
-    tracelog("Serial Opened")
+    tracelog("Serial Opened");
     this._port.on('close', this.onSerialClose);
     this._parser = this._port.pipe(new Delimiter({ delimiter: PACKET_DELIMITER }));
     this._parser.on('data', this.onSerialMessage);

--- a/src/bikes/peloton.js
+++ b/src/bikes/peloton.js
@@ -1,7 +1,6 @@
 import {once, EventEmitter} from 'events';
 import {Timer} from '../util/timer';
 import util from 'util';
-import { trace } from 'console';
 
 const SerialPort = require('serialport')
 const Delimiter = require('@serialport/parser-delimiter')


### PR DESCRIPTION
Adding a trace logger to give us the ability to dump the direct data frames from the serial (assuming they're still f6 delimited).

This should help give us more information as to the wiring config, and I'll likely use this to detect when we have a crossed connection (and be able to warn on that in Gymnasticon).