### PR TITLE
Extract dropout filter and add unit tests.

### DIFF
--- a/src/test/util/dropout-filter.js
+++ b/src/test/util/dropout-filter.js
@@ -1,0 +1,40 @@
+import test from 'tape';
+import {createDropoutFilter} from '../../util/dropout-filter';
+
+test('fill spurious zero power measurements with previous value', t => {
+  const filter = createDropoutFilter();
+  let r;
+
+  r = filter({ power: 100, cadence: 101 });
+  t.equal(r.power, 100, 'power (watts)');
+  t.equal(r.cadence, 101, 'cadence (rpm)');
+
+  r = filter({ power: 0, cadence: 101 });
+  t.equal(r.power, 100, 'power (watts)');
+  t.equal(r.cadence, 101, 'cadence (rpm)');
+
+  r = filter({ power: 0, cadence: 101 });
+  t.equal(r.power, 0, 'power (watts)');
+  t.equal(r.cadence, 101, 'cadence (rpm)');
+
+  t.end();
+});
+
+test('fill spurious zero cadence measurements with previous value', t => {
+  const filter = createDropoutFilter();
+  let r;
+
+  r = filter({ power: 100, cadence: 101 });
+  t.equal(r.power, 100, 'power (watts)');
+  t.equal(r.cadence, 101, 'cadence (rpm)');
+
+  r = filter({ power: 100, cadence: 0 });
+  t.equal(r.power, 100, 'power (watts)');
+  t.equal(r.cadence, 101, 'cadence (rpm)');
+
+  r = filter({ power: 100, cadence: 0 });
+  t.equal(r.power, 100, 'power (watts)');
+  t.equal(r.cadence, 0, 'cadence (rpm)');
+
+  t.end();
+});

--- a/src/util/dropout-filter.js
+++ b/src/util/dropout-filter.js
@@ -1,0 +1,33 @@
+/**
+ * Workaround for an issue in the bikes that occasionally
+ * incorrectly report zero cadence (rpm) or zero power (watts)
+ *
+ * Power dropouts have been observed on the Flywheel bike
+ * Power and cadence dropouts have been observed on the Keiser bike
+ *
+ * This filter can be used for both bikes.
+ */
+export function createDropoutFilter() {
+  let prev = null;
+
+  /**
+   * Returns stats payload with spurious zero removed.
+   * @param {object} curr - current stats payload
+   * @param {number} curr.power - power (watts)
+   * @param {number} curr.cadence - cadence (rpm)
+   * @returns {object} fixed - fixed stats payload
+   * @returns {object} fixed.power - fixed power (watts)
+   * @returns {object} fixed.cadence - cadence
+   */
+  return function (curr) {
+    let fixed = {...curr};
+    if (prev !== null && curr.power === 0 && curr.cadence > 0 && prev.power > 0) {
+      fixed.power = prev.power;
+    }
+    if (prev !== null && curr.cadence === 0 && curr.power > 0 && prev.cadence > 0) {
+      fixed.cadence = prev.cadence;
+    }
+    prev = curr;
+    return fixed;
+  }
+}


### PR DESCRIPTION
There are now two bikes that have spurious zero issues. Flywheel has the
issue with power. Keiser has the issue with both power and cadence. The
same filter can be used for both bikes and remove some duplication in
the code. Also adds some tests. Fixes #56.