### PR TITLE
Detect Keiser bike version and set stats timeout accordingly.

### DIFF
--- a/src/bikes/keiser.js
+++ b/src/bikes/keiser.js
@@ -9,8 +9,12 @@ const KEISER_VALUE_MAGIC = Buffer.from([0x02, 0x01]); // identifies Keiser data 
 const KEISER_VALUE_IDX_POWER = 10; // 16-bit power (watts) data offset within packet
 const KEISER_VALUE_IDX_CADENCE = 6; // 16-bit cadence (1/10 rpm) data offset within packet
 const KEISER_VALUE_IDX_REALTIME = 4; // Indicates whether the data present is realtime (0, or 128 to 227)
-const KEISER_STATS_TIMEOUT = 2.0; // If no stats have been received within this time, reset power and cadence to 0
-const KEISER_BIKE_TIMEOUT = 300.0; // Consider bike disconnected if no stats have been received for 300 sec / 5 minutes
+const KEISER_VALUE_IDX_VMAJOR = 2; // 8-bit Version Major data offset within packet
+const KEISER_VALUE_IDX_VMINOR = 3; // 8-bit Version Major data offset within packet
+const KEISER_STATS_NEWVER_MINOR = 30; // Version Minor when broeadcast interval was changed from ~ 2 sec to ~ 0.3 sec
+const KEISER_STATS_TIMEOUT_OLD = 7.0; // Old Bike: If no stats have been received within 7 sec, reset power and cadence to 0
+const KEISER_STATS_TIMEOUT_NEW = 1.0; // New Bike: If no stats have been received within 1 sec, reset power and cadence to 0
+const KEISER_BIKE_TIMEOUT = 60.0; // Consider bike disconnected if no stats have been received for 60 sec / 1 minutes
 
 const debuglog = util.debuglog('gymnasticon:bikes:keiser');
 
@@ -44,8 +48,24 @@ export class KeiserBikeClient extends EventEmitter {
       throw new Error('Already connected');
     }
 
+    // Scan for bike
+    this.filters = {};
+    this.filters.name = (v) => v == KEISER_LOCALNAME;
+    this.peripheral = await scan(this.noble, null, this.filters);
+
+    this.state = 'connected';
+
+    // Determine bike firmware version and set stats timeout
+    var bikestatstimeout = KEISER_STATS_TIMEOUT_OLD; // Fallback for unknown firmware version
+    try {
+      bikestatstimeout = bikeVersion(this.peripheral.advertisement.manufacturerData);
+    } catch (e) {
+      console.log("Keiser M3 bike: Unknown version detected");
+      this.onBikeTimeout();
+    }
+
     // Reset stats to 0 when bike suddenly dissapears
-    this.statsTimeout = new Timer(KEISER_STATS_TIMEOUT, {repeats: false});
+    this.statsTimeout = new Timer(bikestatstimeout, {repeats: false});
     this.statsTimeout.on('timeout', this.onStatsTimeout.bind(this));
 
     // Consider bike disconnected if no stats have been received for certain time
@@ -54,13 +74,6 @@ export class KeiserBikeClient extends EventEmitter {
 
     // Create filter to fix power and cadence dropouts
     this.fixDropout = createDropoutFilter();
-
-    // Scan for bike
-    this.filters = {};
-    this.filters.name = (v) => v == KEISER_LOCALNAME;
-    this.peripheral = await scan(this.noble, null, this.filters);
-
-    this.state = 'connected';
 
     // Waiting for data
     await this.noble.startScanningAsync(null, true);
@@ -157,6 +170,34 @@ export class KeiserBikeClient extends EventEmitter {
       console.log("Unable to restart BLE Scan: " + err);
     }
   }
+}
+
+/**
+ * Determine Keiser Bike Firmware version.
+ * This helps determine the correct value for the Stats
+ * timeout. Older versions of the bike send data only every
+ * 2 seconds, while newer bikes send data every 300 ms.
+ * @param {buffer} data - raw characteristic value.
+ * @returns {string} version - bike version number as string
+ * @returns {object} timeout - stats timeout for this bike version
+ */
+export function bikeVersion(data) {
+  var version = "Unknown";
+  var timeout = KEISER_STATS_TIMEOUT_OLD;
+  if (data.indexOf(KEISER_VALUE_MAGIC) === 0) {
+    const major = data.readUInt8(KEISER_VALUE_IDX_VMAJOR);
+    const minor = data.readUInt8(KEISER_VALUE_IDX_VMINOR);
+
+    version = major.toString(16) + "." + minor.toString(16);
+    if (major === 6) {
+      if (minor >= parseInt(KEISER_STATS_NEWVER_MINOR, 16)) {
+        timeout = KEISER_STATS_TIMEOUT_NEW;
+      }
+    }
+    console.log("Keiser M3 bike version: ", version, " (Stats Timeout: ", timeout, " sec.)");
+    return timeout;
+  }
+  throw new Error('unable to parse bike version');
 }
 
 /**

--- a/src/bikes/keiser.js
+++ b/src/bikes/keiser.js
@@ -11,9 +11,9 @@ const KEISER_VALUE_IDX_CADENCE = 6; // 16-bit cadence (1/10 rpm) data offset wit
 const KEISER_VALUE_IDX_REALTIME = 4; // Indicates whether the data present is realtime (0, or 128 to 227)
 const KEISER_VALUE_IDX_VMAJOR = 2; // 8-bit Version Major data offset within packet
 const KEISER_VALUE_IDX_VMINOR = 3; // 8-bit Version Major data offset within packet
-const KEISER_STATS_NEWVER_MINOR = 30; // Version Minor when broeadcast interval was changed from ~ 2 sec to ~ 0.3 sec
-const KEISER_STATS_TIMEOUT_OLD = 7.0; // Old Bike: If no stats have been received within 7 sec, reset power and cadence to 0
-const KEISER_STATS_TIMEOUT_NEW = 1.0; // New Bike: If no stats have been received within 1 sec, reset power and cadence to 0
+const KEISER_STATS_NEWVER_MINOR = 30; // Version Minor when broadcast interval was changed from ~ 2 sec to ~ 0.3 sec
+const KEISER_STATS_TIMEOUT_OLD = 7.0; // Old Bike: If no stats received within 7 sec, reset power and cadence to 0
+const KEISER_STATS_TIMEOUT_NEW = 1.0; // New Bike: If no stats received within 1 sec, reset power and cadence to 0
 const KEISER_BIKE_TIMEOUT = 60.0; // Consider bike disconnected if no stats have been received for 60 sec / 1 minutes
 
 const debuglog = util.debuglog('gymnasticon:bikes:keiser');
@@ -187,17 +187,14 @@ export function bikeVersion(data) {
   if (data.indexOf(KEISER_VALUE_MAGIC) === 0) {
     const major = data.readUInt8(KEISER_VALUE_IDX_VMAJOR);
     const minor = data.readUInt8(KEISER_VALUE_IDX_VMINOR);
-
     version = major.toString(16) + "." + minor.toString(16);
-    if (major === 6) {
-      if (minor >= parseInt(KEISER_STATS_NEWVER_MINOR, 16)) {
-        timeout = KEISER_STATS_TIMEOUT_NEW;
-      }
+    if ((major === 6) && (minor >= parseInt(KEISER_STATS_NEWVER_MINOR, 16))) {
+      timeout = KEISER_STATS_TIMEOUT_NEW;
     }
-    console.log("Keiser M3 bike version: ", version, " (Stats Timeout: ", timeout, " sec.)");
+    console.log("Keiser M3 bike version: ", version, " (Stats timeout: ", timeout, " sec.)");
     return { version, timeout };
   }
-  throw new Error('unable to parse bike version');
+  throw new Error('unable to parse bike version data');
 }
 
 /**

--- a/src/bikes/keiser.js
+++ b/src/bikes/keiser.js
@@ -9,8 +9,8 @@ const KEISER_VALUE_MAGIC = Buffer.from([0x02, 0x01]); // identifies Keiser data 
 const KEISER_VALUE_IDX_POWER = 10; // 16-bit power (watts) data offset within packet
 const KEISER_VALUE_IDX_CADENCE = 6; // 16-bit cadence (1/10 rpm) data offset within packet
 const KEISER_VALUE_IDX_REALTIME = 4; // Indicates whether the data present is realtime (0, or 128 to 227)
-const KEISER_VALUE_IDX_VMAJOR = 2; // 8-bit Version Major data offset within packet
-const KEISER_VALUE_IDX_VMINOR = 3; // 8-bit Version Major data offset within packet
+const KEISER_VALUE_IDX_VER_MAJOR = 2; // 8-bit Version Major data offset within packet
+const KEISER_VALUE_IDX_VER_MINOR = 3; // 8-bit Version Major data offset within packet
 const KEISER_STATS_NEWVER_MINOR = 30; // Version Minor when broadcast interval was changed from ~ 2 sec to ~ 0.3 sec
 const KEISER_STATS_TIMEOUT_OLD = 7.0; // Old Bike: If no stats received within 7 sec, reset power and cadence to 0
 const KEISER_STATS_TIMEOUT_NEW = 1.0; // New Bike: If no stats received within 1 sec, reset power and cadence to 0
@@ -56,12 +56,12 @@ export class KeiserBikeClient extends EventEmitter {
     this.state = 'connected';
 
     // Determine bike firmware version and set stats timeout
-    var bikestatstimeout = KEISER_STATS_TIMEOUT_OLD; // Fallback for unknown firmware version
+    let bikestatstimeout = KEISER_STATS_TIMEOUT_OLD; // Fallback for unknown firmware version
     try {
       bikestatstimeout = bikeVersion(this.peripheral.advertisement.manufacturerData).timeout;
     } catch (e) {
       console.log("Keiser M3 bike: Unknown version detected");
-      this.onBikeTimeout();
+      this.onBikeTimeout(); // Disconnect as this data cannot be handled
     }
 
     // Reset stats to 0 when bike suddenly dissapears
@@ -182,11 +182,11 @@ export class KeiserBikeClient extends EventEmitter {
  * @returns {object} timeout - stats timeout for this bike version
  */
 export function bikeVersion(data) {
-  var version = "Unknown";
-  var timeout = KEISER_STATS_TIMEOUT_OLD;
+  let version = "Unknown";
+  let timeout = KEISER_STATS_TIMEOUT_OLD;
   if (data.indexOf(KEISER_VALUE_MAGIC) === 0) {
-    const major = data.readUInt8(KEISER_VALUE_IDX_VMAJOR);
-    const minor = data.readUInt8(KEISER_VALUE_IDX_VMINOR);
+    const major = data.readUInt8(KEISER_VALUE_IDX_VER_MAJOR);
+    const minor = data.readUInt8(KEISER_VALUE_IDX_VER_MINOR);
     version = major.toString(16) + "." + minor.toString(16);
     if ((major === 6) && (minor >= parseInt(KEISER_STATS_NEWVER_MINOR, 16))) {
       timeout = KEISER_STATS_TIMEOUT_NEW;

--- a/src/bikes/keiser.js
+++ b/src/bikes/keiser.js
@@ -58,7 +58,7 @@ export class KeiserBikeClient extends EventEmitter {
     // Determine bike firmware version and set stats timeout
     var bikestatstimeout = KEISER_STATS_TIMEOUT_OLD; // Fallback for unknown firmware version
     try {
-      bikestatstimeout = bikeVersion(this.peripheral.advertisement.manufacturerData);
+      bikestatstimeout = bikeVersion(this.peripheral.advertisement.manufacturerData).timeout;
     } catch (e) {
       console.log("Keiser M3 bike: Unknown version detected");
       this.onBikeTimeout();
@@ -195,7 +195,7 @@ export function bikeVersion(data) {
       }
     }
     console.log("Keiser M3 bike version: ", version, " (Stats Timeout: ", timeout, " sec.)");
-    return timeout;
+    return { version, timeout };
   }
   throw new Error('unable to parse bike version');
 }

--- a/src/test/bikes/keiser.js
+++ b/src/test/bikes/keiser.js
@@ -13,3 +13,35 @@ test('parse() parses Keiser indoor bike data values', t => {
   t.equal(cadence, 82, 'cadence (rpm)');
   t.end();
 });
+
+test('bikeVersion() Tests Keiser bike version (6.40)', t => {
+  const bufver = Buffer.from('0201064000383803460573000D00042701000A', 'hex');
+  const {version, timeout} = bikeVersion(bufver);
+  t.equal(version, '6.40', 'Version: 6.40');
+  t.equal(timeout, 1, 'Timeout: 1 second');
+  t.end();
+});
+
+test('bikeVersion() Tests Keiser bike version (6.30)', t => {
+  const bufver = Buffer.from('0201063000383803460573000D00042701000A', 'hex');
+  const {version, timeout} = bikeVersion(bufver);
+  t.equal(version, '6.30', 'Version: 6.30');
+  t.equal(timeout, 1, 'Timeout: 1 second');
+  t.end();
+});
+
+test('bikeVersion() Tests Keiser bike version (6.22)', t => {
+  const bufver = Buffer.from('0201062200383803460573000D00042701000A', 'hex');
+  const {version, timeout} = bikeVersion(bufver);
+  t.equal(version, '6.22', 'Version: 6.22');
+  t.equal(timeout, 7, 'Timeout: 7 second');
+  t.end();
+});
+
+test('bikeVersion() Tests Keiser bike version (5.12)', t => {
+  const bufver = Buffer.from('0201051200383803460573000D00042701000A', 'hex');
+  const {version, timeout} = bikeVersion(bufver);
+  t.equal(version, '5.12', 'Version: 5.12');
+  t.equal(timeout, 7, 'Timeout: 7 second');
+  t.end();
+});

--- a/src/test/bikes/keiser.js
+++ b/src/test/bikes/keiser.js
@@ -1,5 +1,6 @@
 import test from 'tape';
 import {parse} from '../../bikes/keiser';
+import {bikeVersion} from '../../bikes/keiser';
 
 /**
  * See https://dev.keiser.com/mseries/direct/#data-parse-example for a


### PR DESCRIPTION
Keiser changed the broadcast interval in [firmware revision 6.30](https://dev.keiser.com/mseries/direct/#revision-history) from ~ 2 seconds to ~ 0.3 seconds. As a result bikes before version 6.30 (old) need to use a higher stats timeout value of 7 seconds to detect a communication failure, while bikes starting with version 6.30 (new) can use a lower stats timeout value of 1 second. 

This change determines the bikes firmware version on first discovery and sets the stats timeout value accordingly. 
For unknown firmware versions (e.g. 5.12, which doesn't exist) a "safe" stats timeout value of 7 seconds is considered. 