### PR TITLE
Support for Pi HW watchdog

### DIFF
--- a/deploy/pi-sdcard/stage-gymnasticon/00-install-gymnasticon/00-packages
+++ b/deploy/pi-sdcard/stage-gymnasticon/00-install-gymnasticon/00-packages
@@ -1,1 +1,2 @@
 libudev-dev
+watchdog

--- a/deploy/pi-sdcard/stage-gymnasticon/00-install-gymnasticon/01-run.sh
+++ b/deploy/pi-sdcard/stage-gymnasticon/00-install-gymnasticon/01-run.sh
@@ -29,7 +29,12 @@ install -v -m 644 files/gymnasticon.json "${ROOTFS_DIR}/etc/gymnasticon.json"
 install -v -m 644 files/gymnasticon.service "${ROOTFS_DIR}/etc/systemd/system/gymnasticon.service"
 install -v -m 644 files/gymnasticon-mods.service "${ROOTFS_DIR}/etc/systemd/system/gymnasticon-mods.service"
 
+install -v -m 644 files/watchdog.conf "${ROOTFS_DIR}/etc/watchdog.conf"
+
 on_chroot <<EOF
+echo 'dtparam=watchdog=on' >> /boot/config.txt
+systemctl enable watchdog
+
 systemctl enable gymnasticon
 systemctl enable gymnasticon-mods
 EOF

--- a/deploy/pi-sdcard/stage-gymnasticon/00-install-gymnasticon/files/watchdog.conf
+++ b/deploy/pi-sdcard/stage-gymnasticon/00-install-gymnasticon/files/watchdog.conf
@@ -1,0 +1,5 @@
+watchdog-device = /dev/watchdog
+watchdog-timeout = 15
+max-load-1 = 24
+min-memory = 1
+allocatable-memory = 1


### PR DESCRIPTION
Related to pull request #58, but broken out in separate pull request to discuss feasibility:

Support for the Raspberry Pi built-in hardware watchdog. This allows the Pi to reboot in case of a failure, including e.g.:
-  Kernel Panics
- Very High CPU load (> 24)
- Out of memory

Can be tested with a fork bomb like:
`sudo bash -c ':(){ :|:& };:'`