### PR TITLE
Fix file-not-found issue in pi-sdcard build process

### DIFF
--- a/deploy/pi-sdcard/stage-gymnasticon/00-install-gymnasticon/01-run.sh
+++ b/deploy/pi-sdcard/stage-gymnasticon/00-install-gymnasticon/01-run.sh
@@ -8,9 +8,8 @@ GYMNASTICON_GROUP=${FIRST_USER_NAME}
 if [ ! -x "${ROOTFS_DIR}/opt/gymnasticon/node/bin/node" ] ; then
   TMPD=$(mktemp -d)
   trap 'rm -rf $TMPD' EXIT
-  cd $TMPD
-  curl -Lo node.tar.gz ${NODE_URL}
-  sha256sum -c <(echo "$NODE_SHASUM256 node.tar.gz")
+  curl -Lo $TMPD/node.tar.gz ${NODE_URL}
+  sha256sum -c <(echo "$NODE_SHASUM256 $TMPD/node.tar.gz")
   install -v -m 644 "$TMPD/node.tar.gz" "${ROOTFS_DIR}/tmp/node.tar.gz"
   on_chroot <<EOF
     mkdir -p /opt/gymnasticon/node


### PR DESCRIPTION
Use absolute path for curl and sha256sum to prevent changing path into tmp dir. This prevents subsequent path not found errors.  