### PR TITLE
simpler instructions on adding the gynasticon.json config

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Steps:
 
 Config file:
 
-If using another bike than Flywheel or Peloton, create and adapt a gymnasticon.json file within the [boot folder](https://www.raspberrypi.org/documentation/configuration/boot_folder.md) of the SD card.
+If using a bike other than Flywheel or Peloton - create and adapt a `gymnasticon.json` file within the main folder of the SD card. It should end up in the same folder as `bootcode.bin`, `cmdline.txt`, `config.txt`, etc.
 
 The following example configures Gymnasticon to look for a Schwinn IC4 bike and to reduce its power measurement values by 8%:
 


### PR DESCRIPTION
The link to the boot folder info for rasberry pi was very confusing for me personally. All I really needed to know was that the file needed to go into the main folder on the SD card. I updated the wording to try and make it easier to understand.